### PR TITLE
Add localization for DOM elements

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -100,8 +100,18 @@ function init(i18next, options={}){
         }
     }
 
-    function handle(selector, opts){
-        var elems = options.document.querySelectorAll(selector);
+    function handle(selectorOrElements, opts){
+        var elems;
+        if(typeof selectorOrElements === 'string') {
+            // Assume query selector
+            elems = options.document.querySelectorAll(selectorOrElements);
+        } else if(Array.isArray(selectorOrElements)) {
+            // Assume array of elements
+            elems = selectorOrElements;
+        } else {
+            // Assume single element
+            elems = [selectorOrElements];
+        }
         for(let i = 0; i < elems.length; i++){
             let elem = elems[i];
             let childs = elem.querySelectorAll('[' + options.selectorAttr + ']');


### PR DESCRIPTION
This allows to localize elements that are not currently attached to the DOM tree,
such as elements just created via document.createElement() or elements that are
managed by a third party library.

The use case is something like this:
```
const div = document.createElement('div');
div.setAttribute('data-i18n','the.key');
localize(div);

// later
parent.appendChild(div);
```

I have to admit that my changes are entirely untested. I just edited and commited directly on github. Hope it works anyway.