### PR TITLE
Closes #21: Pass a custom document object to the options of handle

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,17 @@ localize("#btn1");
 localize("#btn1");
 ```
 
+### use a custom `document` object
+```js
+<template id="template">
+  <a id="btn1" href="#" data-i18n="myKey"></a>
+</template>
+const shadowRoot = document.body.attachShadow();
+const template = document.getElementById("template");
+shadowRoot.appendChild(template.content.cloneNode(true));
+localize("#btn1", {document: shadowRoot});
+```
+
 ## Motivation
 - Having an occasion to try some packages like rollup, babel or uglify.
 - Obtaining the same kind of functionnalities than with `jquery-i18next` in a project not using jquery.

--- a/src/main.js
+++ b/src/main.js
@@ -101,7 +101,8 @@ function init(i18next, options={}){
     }
 
     function handle(selector, opts){
-        var elems = options.document.querySelectorAll(selector);
+        const document = opts?.document || options.document;
+        var elems = document.querySelectorAll(selector);
         for(let i = 0; i < elems.length; i++){
             let elem = elems[i];
             let childs = elem.querySelectorAll('[' + options.selectorAttr + ']');


### PR DESCRIPTION
Allow passing a custom `document` object to the options of `handle`. Currently, this is only possible during init, globally. This solves issue #21 