### PR TITLE
Fix ReferenceError when ran outside the browser

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -4,7 +4,8 @@ const defaults = {
     optionsAttr: 'i18n-options',
     useOptionsAttr: false,
     parseDefaultValueFromContent: true,
-    document: document,
+    // `document` if running inside a browser, but otherwise undefined (prevents reference error when ran outside browser)
+    document: typeof window !== 'undefined' ? document : undefined,
 };
 
 function init(i18next, options={}){


### PR DESCRIPTION
Hi,

I'm using loc-i18next to make a Parcel transformer so I can statically render the HTML, however the code will return a ReferenceError if the `document` object does not exist (eg. in a node environment or otherwise outside the browser). I've modified this line so it will work in both browser and non-browser contents. 

- Browser will use `document`
- Non-browser will be `undefined`.

I've tested this in both browser and node and both appear to work.